### PR TITLE
IMB-107: Scheduled job - Validate and Store Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,15 +58,19 @@ If creating a new service you can add a new folder within /services named as the
 
 ```javascript
 module.exports = {
-  targetColumns: ['array', 'of', 'strings'], // OPTIONAL. If your target table's column names are different to those in the original CSV (e.g. the CSV column names are in a format that can't be used in SQL commands) list the target table's columns here. Remove this property if there is no need to alter the column names during processing.
-  validations: [
-    function validationOne(row) {},
-    function validationTwo(row) {},
-    function validationThree(row) {}
-  ] // OPTIONAL. Add functions to run against the data where the row is added as an argument.
+  targetColumns: ['array', 'of', 'strings'],
+  validateRecord: function (record) {return { valid: true }}
 };
 
 ```
+
+Both options in this exported config object are optional.
+
+When the csv-parse module parses CSV it creates an object for each record of key/value pairs where the key is the column name and the value is the entry in that column in the CSV row. The object has a key/value pair for each column. `targetColumns` can optionally be defined as an array if you want to replace the CSV column names with something else in the parsed object - for example if the CSV column name is in a longform string format that is inconvenient to work with. This array must have a length the same as the number of columns in the CSV and an item to replace each column name from left to right. If this property is not exported the parsed object will use the CSV column names by default.
+
+If the `validateRecord` property is defined as a function with one `record` argument the script will use that function to validate records row by row. The function must return at least an object with a bool type `valid` property. e.g. `{ valid: true }`. Records returning `{ valid: true }` from this function are added to the `records` array, those that return `{ valid: false }` are added to the `invalidRecords` array. Check existing implementation for examples.
+
+If no `validateRecord` propery is defined then the script will add all CSV rows to `records` without validation.
 
 ### Keycloak
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ A Node.js script for replacing database lookup tables as a scheduled job configu
 
 The script retrieves a CSV formatted file from a given location, validates against given rules and then replaces a lookup table using the CSV rows. On success or failure the script will send appropriate notification messages.
 
+This script only makes certain assumptions about the service it will update the RDS lookup table for:
+
+1. That the service runs an RDS (e.g PostgreSQL database).
+2. That the service's RDS has a named table with at least columns 'id', 'url' and 'created_at' where http(s) links to CSV data can be fetched from.
+3. That the service's RDS has an existing, named table with the appropriate columns that can be dropped and replaced completely by a copy containing the latest CSV data.
+4. That the script will need to autheticate with Keycloak and provide a token with its incoming data request, or the data source requires no authentication. See [Keycloak](#keycloak).
+
 This repository currently offers either [pg-promise](https://vitaly-t.github.io/pg-promise/index.html) or [knex.js](https://knexjs.org/) to handle db connection and query building. You can configure the client and model used using environment variables.
 
 Some [documentation of the high level design process for the lookup replacer](https://collaboration.homeoffice.gov.uk/display/DSASS/High+Level+Ellaboration+-+IMB-68) can be found in the HOF Confluence.
@@ -45,11 +52,27 @@ The /db/models folder contains models for available clients providing exported c
 
 ### Service
 
-The /services folder contains service specific configuration that is difficult to inject as environment variables - such as validation rules. Setting the `SERVICE_NAME` environment variable to one of the service name subfolders in /services should allow the app to run with that folder's specific configurations.
+The /services folder contains service specific configuration. Setting the `SERVICE_NAME` environment variable correctly for your intended service should allow the app to run with that service's specific configurations.
+
+If creating a new service you can add a new folder within /services named as the shortname for your service (e.g. asc, ima, acq). Within that folder add a `config.js` as follows:
+
+```javascript
+module.exports = {
+  targetColumns: ['array', 'of', 'strings'], // OPTIONAL. If your target table's column names are different to those in the original CSV (e.g. the CSV column names are in a format that can't be used in SQL commands) list the target table's columns here. Remove this property if there is no need to alter the column names during processing.
+  validations: [
+    function validationOne(row) {},
+    function validationTwo(row) {},
+    function validationThree(row) {}
+  ] // OPTIONAL. Add functions to run against the data where the row is added as an argument.
+};
+
+```
 
 ### Keycloak
 
 This script must authenticate with the service's Keycloak realm and receive a bearer token to allow authorised requests to the service's file-vault. Keycloak auth secrets are configured as environment variables.
+
+It is possible to use a data source that is not protected by Keycloak as long as it either a) supports the same auth protocols as Keycloak in which case environment variables can be substituted like for like, or b) if your data source does not require auth at all. In this case if no Keycloak token URL is provided to the environment the script will not attempt to auth and will pass `undefined` into the Axios data request config - meaning no auth headers are added to the outgoing request to the data URL.
 
 ## Build and run
 
@@ -68,8 +91,8 @@ The purpose of this service is to be run as a scheduled job from the main servic
 ```bash
 NODE_ENV # Set to 'local' for local development and testing
 SERVICE_NAME # Shortname for the service to configure validations e.g. ima
-TARGET_TABLE # Target lookup table name to be replaced in the database
-SOURCE_FILE_TABLE # DB table name where this service can get the CSV file's URL from
+TARGET_TABLE # The name of the table in the service RDS where the URLs for uploaded CSV data are stored e.g. csv_urls
+SOURCE_FILE_TABLE # The name of the target table to replace with the newer CSV data. e.g. cepr_lookup
 KEYCLOAK_SECRET # Keycloak secrets to authenticate for retrieval from S3 via file-vault (assuming this is the CSV's persistent location)
 KEYCLOAK_CLIENT_ID
 KEYCLOAK_USERNAME

--- a/db/models/knex-postgres-model.js
+++ b/db/models/knex-postgres-model.js
@@ -2,6 +2,8 @@
 const config = require('../../config');
 const { targetTable, sourceFileTable } = config.service;
 
+const logger = require('../../lib/logger')({ env: config.env });
+
 module.exports = class KnexPostgresModel {
   constructor() {
     this.requestTimeout = config.requestTimeout;
@@ -13,11 +15,16 @@ module.exports = class KnexPostgresModel {
   }
 
   async getLatestUrl(knex) {
-    const result = await knex.select('url')
-      .from(this.sourceFileTable)
-      .orderBy('id', 'desc')
-      .limit(1)
-      .timeout(this.requestTimeout);
-    return result[0].url;
+    try {
+      const result = await knex.select('url')
+        .from(this.sourceFileTable)
+        .orderBy('id', 'desc')
+        .limit(1)
+        .timeout(this.requestTimeout);
+      return result[0].url;
+    } catch (error) {
+      logger.log('error', 'Error retrieving CSV URL');
+      throw error;
+    }
   }
 };

--- a/db/models/knex-postgres-model.js
+++ b/db/models/knex-postgres-model.js
@@ -16,7 +16,7 @@ module.exports = class KnexPostgresModel {
 
   async getLatestUrl(knex) {
     try {
-      const result = await knex.select('url')
+      const result = await knex.select('url', 'created_at')
         .from(this.sourceFileTable)
         .orderBy('id', 'desc')
         .limit(1)

--- a/db/models/pgp-model.js
+++ b/db/models/pgp-model.js
@@ -2,6 +2,8 @@
 const config = require('../../config');
 const { targetTable, sourceFileTable } = config.service;
 
+const logger = require('../../lib/logger')({ env: config.env });
+
 module.exports = class PgpModel {
   constructor() {
     this.requestTimeout = config.requestTimeout;
@@ -19,6 +21,7 @@ module.exports = class PgpModel {
           resolve(data.url);
         })
         .catch(error => {
+          logger.log('error', 'Error retrieving CSV URL');
           reject(error);
         });
     });

--- a/db/models/pgp-model.js
+++ b/db/models/pgp-model.js
@@ -16,7 +16,7 @@ module.exports = class PgpModel {
 
   getLatestUrl(pgp) {
     return new Promise((resolve, reject) => {
-      pgp.one('SELECT url FROM $1~ ORDER BY id DESC LIMIT 1', this.sourceFileTable)
+      pgp.one('SELECT url, created_at FROM $1~ ORDER BY id DESC LIMIT 1', this.sourceFileTable)
         .then(data => {
           resolve(data.url);
         })

--- a/lib/file-vault-utils.js
+++ b/lib/file-vault-utils.js
@@ -30,7 +30,7 @@ const auth = async () =>
       })
       .catch(error => {
         // eslint-disable-next-line no-console
-        logger.log('error', 'Authentication error: ', error);
+        logger.log('error', 'Keycloak authentication error');
         reject(error);
       });
   });

--- a/lib/file-vault-utils.js
+++ b/lib/file-vault-utils.js
@@ -36,14 +36,15 @@ const auth = async () =>
   });
 
 const fileRequestConfig = (url, authToken) => {
-  return {
+  const requestConfig = {
     url: url,
     method: 'get',
-    responseType: 'stream',
-    headers: {
-      Authorization: `Basic ${authToken.bearer}`
-    }
+    responseType: 'stream'
   };
+  if (authToken) {
+    requestConfig.headers = { Authorization: `Basic ${authToken.bearer}` };
+  }
+  return requestConfig;
 };
 
 module.exports = { auth, fileRequestConfig };

--- a/package.json
+++ b/package.json
@@ -38,8 +38,9 @@
       "**/*.js",
       "!**/node_modules/**",
       "!**/coverage/**",
-      "!**/config.js",
-      "!**/logger.js"
+      "!config.js",
+      "!**/logger.js",
+      "!**/db/*"
     ]
   }
 }

--- a/run.js
+++ b/run.js
@@ -13,6 +13,12 @@ const client = require(`./db/${config.db.client}`);
 const Model = require(`./db/models/${config.db.model}`);
 const db = new Model();
 
+// Log memory usage over time.
+// TODO Remove this before prod
+// setInterval(() => {
+//   logger.log('info', `Used: ${process.memoryUsage().heapUsed / 1024 / 1024}`);
+// }, 50);
+
 async function runUpdate() {
   if (!serviceName) {
     logger.log('error', 'No service name detected in config');
@@ -22,12 +28,6 @@ async function runUpdate() {
   logger.log('info', `Preparing table update for ${serviceName}`);
 
   try {
-    // Log memory usage over time.
-    // TODO Remove this before prod
-    // setInterval(() => {
-    //   logger.log('info', `Used: ${process.memoryUsage().heapUsed / 1024 / 1024}`);
-    // }, 50);
-
     // Get the most recent CSV data URL from RDS
     logger.log('info', 'Getting data file location from RDS');
     const dataFileUrl = await db.getLatestUrl(client);

--- a/run.js
+++ b/run.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-cond-assign */
 const config = require('./config');
 const { serviceName } = config.service;
-const { targetColumns, validator } = require(`./services/${serviceName}/config`);
+const { targetColumns, validateRecord } = require(`./services/${serviceName}/config`);
 
 const axios = require('axios');
 const { parse } = require('csv-parse');
@@ -29,12 +29,15 @@ async function runUpdate() {
     // }, 50);
 
     // Get the most recent CSV data URL from RDS
+    logger.log('info', 'Getting data file location from RDS');
     const dataFileUrl = await db.getLatestUrl(client);
 
     // Authenticate with Keycloak and receive token
+    logger.log('info', 'Getting file retrival token');
     const fvToken = config.keycloak.tokenUrl ? await fv.auth() : undefined;
 
     // Get the data file as a stream using URL and token
+    logger.log('info', 'Connecting to file retrival URL');
     const response = await axios(fv.fileRequestConfig(dataFileUrl, fvToken));
     const axiosStream = response.data;
 
@@ -55,30 +58,34 @@ async function runUpdate() {
     parser.on('readable', () => {
       let record;
       while ((record = parser.read()) !== null) {
-        // Validate records against any validator functions set in service config.
-        const result = validator.records(record);
-        if (result.valid) {
-          records.push(record);
+        // Validate records against function set in service config.
+        if (validateRecord) {
+          const report = validateRecord(record);
+          if (report.valid) {
+            records.push(record);
+          } else {
+            invalidRecords.push(report);
+          }
         } else {
-          invalidRecords.push(result);
+          records.push(record);
         }
       }
       // It may also be possble to batch insert from here in chunks rather than load all records into memory.
     });
 
     parser.on('error', error => {
-      logger.log('error', `CSV parsing error: ${error.message}`);
+      logger.log('error', `CSV processing error: ${error.message}`);
       throw error;
     });
 
     parser.on('end', async () => {
-      // eslint-disable-next-line no-console
       console.log('RECORDS: ', records);
       console.log('INVALID RECORDS: ', invalidRecords);
-      // logger.log('info', `Records parsed from rows ${records[0].cepr} to ${records[records.length - 1].cepr}`);
+      logger.log('info', 'Job complete!');
     });
 
     // Start streaming data from Axios into CSV parser
+    logger.log('info', 'Streaming CSV data from data file');
     axiosStream.pipe(parser);
   } catch (error) {
     logger.log('error', `${error.message}`);

--- a/run.js
+++ b/run.js
@@ -13,12 +13,6 @@ const client = require(`./db/${config.db.client}`);
 const Model = require(`./db/models/${config.db.model}`);
 const db = new Model();
 
-// Log memory usage over time.
-// TODO Remove this before prod
-// setInterval(() => {
-//   logger.log('info', `Used: ${process.memoryUsage().heapUsed / 1024 / 1024}`);
-// }, 50);
-
 async function runUpdate() {
   try {
     logger.log('info', `Preparing table update for ${serviceName}`);

--- a/run.js
+++ b/run.js
@@ -20,14 +20,9 @@ const db = new Model();
 // }, 50);
 
 async function runUpdate() {
-  if (!serviceName) {
-    logger.log('error', 'No service name detected in config');
-    return;
-  }
-
-  logger.log('info', `Preparing table update for ${serviceName}`);
-
   try {
+    logger.log('info', `Preparing table update for ${serviceName}`);
+
     // Get the most recent CSV data URL from RDS
     logger.log('info', 'Getting data file location from RDS');
     const dataFileUrl = await db.getLatestUrl(client);

--- a/run.js
+++ b/run.js
@@ -12,6 +12,11 @@ const Model = require(`./db/models/${config.db.model}`);
 const db = new Model();
 
 async function runUpdate() {
+  if (!config.service.serviceName) {
+    logger.log('error', 'No service name detected in config');
+    return;
+  }
+
   logger.log('info', `Preparing table update for ${config.service.serviceName}`);
 
   try {
@@ -36,7 +41,7 @@ async function runUpdate() {
     const parser = parse({ from: 2, trim: true, columns: ['cepr', 'dob', 'dtr']});
 
     axiosStream.on('error', error => {
-      logger.log('error', 'Axios stream error: ', error.message);
+      logger.log('error', `Axios stream error: ${error.message}`);
       throw error;
     });
 
@@ -54,7 +59,7 @@ async function runUpdate() {
     });
 
     parser.on('error', error => {
-      logger.log('error', 'CSV parsing error: ', error.message);
+      logger.log('error', `CSV parsing error: ${error.message}`);
       throw error;
     });
 
@@ -67,7 +72,7 @@ async function runUpdate() {
     // Start streaming data from Axios into CSV parser
     axiosStream.pipe(parser);
   } catch (error) {
-    logger.log('error', 'error:', error);
+    logger.log('error', `${error.message}`);
   }
 }
 

--- a/services/ima/config.js
+++ b/services/ima/config.js
@@ -19,7 +19,7 @@ function validateRecords(record) {
     invalidReasons.push('Invalid CEPR value');
   };
 
-  const validDob = /^(0?[1-9]|[12][0-9]|3[01])[\/\-](0?[1-9]|1[012])[\/\-]\d{4}$/.test(dob);
+  const validDob = /^(\d{2}\/\d{2}\/\d{4})?$/.test(dob);
   if (!validDob) {
     report.valid = false;
     invalidReasons.push('Invalid DOB format');
@@ -33,7 +33,7 @@ function validateRecords(record) {
   };
 
   if (invalidReasons.length) {
-    report.reasons = invalidReasons.join(', ');
+    report.reasons = invalidReasons;
   };
 
   return report;

--- a/services/ima/config.js
+++ b/services/ima/config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  targetColumns: ['cepr', 'dob', 'dtr'],
+  validations: {
+    'cepr': '',
+    'dob': '',
+    'drt': ''
+  }
+};

--- a/services/ima/config.js
+++ b/services/ima/config.js
@@ -1,8 +1,40 @@
 module.exports = {
   targetColumns: ['cepr', 'dob', 'dtr'],
-  validations: {
-    'cepr': '',
-    'dob': '',
-    'drt': ''
+  validator: {
+    records: validateRecords
   }
+};
+
+function validateRecords(record) {
+  const { cepr, dob, dtr } = record;
+  const invalidReasons = [];
+  const report = {
+    record: record,
+    valid: true
+  };
+
+  const validCepr = /^([0-9]{6,10}?)$/.test(cepr);
+  if (!validCepr) {
+    report.valid = false;
+    invalidReasons.push('Invalid CEPR value');
+  };
+
+  const validDob = /^(0?[1-9]|[12][0-9]|3[01])[\/\-](0?[1-9]|1[012])[\/\-]\d{4}$/.test(dob);
+  if (!validDob) {
+    report.valid = false;
+    invalidReasons.push('Invalid DOB format');
+  };
+
+  const dtrValue = dtr.toLowerCase();
+  const validDtr = (dtrValue === 'yes' || dtrValue === 'no') ? true : false;
+  if (!validDtr) {
+    report.valid = false;
+    invalidReasons.push('Invalid Duty to remove alert value');
+  };
+
+  if (invalidReasons.length) {
+    report.reasons = invalidReasons.join(', ');
+  };
+
+  return report;
 };

--- a/services/ima/config.js
+++ b/services/ima/config.js
@@ -1,11 +1,9 @@
 module.exports = {
   targetColumns: ['cepr', 'dob', 'dtr'],
-  validator: {
-    records: validateRecords
-  }
+  validateRecord: validateRecord
 };
 
-function validateRecords(record) {
+function validateRecord(record) {
   const { cepr, dob, dtr } = record;
   const invalidReasons = [];
   const report = {
@@ -25,8 +23,7 @@ function validateRecords(record) {
     invalidReasons.push('Invalid DOB format');
   };
 
-  const dtrValue = dtr.toLowerCase();
-  const validDtr = (dtrValue === 'yes' || dtrValue === 'no') ? true : false;
+  const validDtr = (dtr === 'Yes' || dtr === 'No') ? true : false;
   if (!validDtr) {
     report.valid = false;
     invalidReasons.push('Invalid Duty to remove alert value');

--- a/services/ima/service-config.json
+++ b/services/ima/service-config.json
@@ -1,3 +1,0 @@
-{
-  "validations": []
-}

--- a/test/unit/file-vault-utils.test.js
+++ b/test/unit/file-vault-utils.test.js
@@ -54,17 +54,27 @@ describe('The auth() function', () => {
 });
 
 describe('The fileRequestConfig() function', () => {
-  const bearer = { bearer: fakeToken };
-  const config = fv.fileRequestConfig(fakeUrl, bearer);
-
   test('should return an object type', () => {
+    const bearer = { bearer: fakeToken };
+    const config = fv.fileRequestConfig(fakeUrl, bearer);
     expect(typeof config === 'object').toBe(true);
   });
 
   test('returned object should have all necessary properties', () => {
+    const bearer = { bearer: fakeToken };
+    const config = fv.fileRequestConfig(fakeUrl, bearer);
     expect(config).toHaveProperty('url', fakeUrl);
     expect(config).toHaveProperty('method', 'get');
     expect(config).toHaveProperty('responseType', 'stream');
     expect(config).toHaveProperty('headers.Authorization', `Basic ${fakeToken}`);
+  });
+
+  test('Returns a config object without auth headers if no auth token is supplied', () => {
+    const bearer = undefined;
+    const config = fv.fileRequestConfig(fakeUrl, bearer);
+    expect(config).toHaveProperty('url', fakeUrl);
+    expect(config).toHaveProperty('method', 'get');
+    expect(config).toHaveProperty('responseType', 'stream');
+    expect(config).not.toHaveProperty('headers.Authorization', `Basic ${fakeToken}`);
   });
 });

--- a/test/unit/ima-config.test.js
+++ b/test/unit/ima-config.test.js
@@ -1,0 +1,77 @@
+const { targetColumns, validator } = require('../../services/ima/config');
+
+describe('The IMA service config', () => {
+  describe('targetColumns array', () => {
+    test('should contain the correct target columns for the lookup db', async () => {
+      expect(targetColumns).toStrictEqual(['cepr', 'dob', 'dtr']);
+    });
+  });
+
+  describe('record validator function', () => {
+    test('should return the correct result object when passed a properly formatted record.', async () => {
+      const record = { cepr: '1000000001', dob: '01/01/2000', dtr: 'Yes' };
+      const result = validator.records(record);
+      expect(result).toHaveProperty('record', record);
+      expect(result).toHaveProperty('valid', true);
+      expect(result).not.toHaveProperty('reasons');
+    });
+
+    test('should return the correct result when passed a record with invalid CEPR value', async () => {
+      const record = { cepr: '1001', dob: '01/01/2000', dtr: 'Yes' };
+      const result = validator.records(record);
+      expect(result).toHaveProperty('record', record);
+      expect(result).toHaveProperty('valid', false);
+      expect(result).toHaveProperty('reasons', ['Invalid CEPR value']);
+    });
+
+    test('should return the correct result when passed a record with invalid DOB value', async () => {
+      const record = { cepr: '1000000001', dob: '01-01-20', dtr: 'Yes' };
+      const result = validator.records(record);
+      expect(result).toHaveProperty('record', record);
+      expect(result).toHaveProperty('valid', false);
+      expect(result).toHaveProperty('reasons', ['Invalid DOB format']);
+    });
+
+    test('should return the correct result when passed a record with invalid DTR value', async () => {
+      const record = { cepr: '1000000001', dob: '01/01/2000', dtr: 'Yeah' };
+      const result = validator.records(record);
+      expect(result).toHaveProperty('record', record);
+      expect(result).toHaveProperty('valid', false);
+      expect(result).toHaveProperty('reasons', ['Invalid Duty to remove alert value']);
+    });
+
+    test('should return the correct result when passed a record with invalid CEPR and DOB value', async () => {
+      const record = { cepr: '1000a', dob: '01012000', dtr: 'Yes' };
+      const result = validator.records(record);
+      expect(result).toHaveProperty('record', record);
+      expect(result).toHaveProperty('valid', false);
+      expect(result).toHaveProperty('reasons', ['Invalid CEPR value', 'Invalid DOB format']);
+    });
+
+    test('should return the correct result when passed a record with invalid CEPR and DTR value', async () => {
+      const record = { cepr: 'ABCDEFGH', dob: '01/01/2000', dtr: 'Yeah' };
+      const result = validator.records(record);
+      expect(result).toHaveProperty('record', record);
+      expect(result).toHaveProperty('valid', false);
+      expect(result).toHaveProperty('reasons', ['Invalid CEPR value', 'Invalid Duty to remove alert value']);
+    });
+
+    test('should return the correct result when passed a record with invalid DOB and DTR value', async () => {
+      const record = { cepr: '1000000001', dob: '1/1/00', dtr: 'Nope' };
+      const result = validator.records(record);
+      expect(result).toHaveProperty('record', record);
+      expect(result).toHaveProperty('valid', false);
+      expect(result).toHaveProperty('reasons', ['Invalid DOB format', 'Invalid Duty to remove alert value']);
+    });
+
+    test('should return the correct result when all record values are invalid', async () => {
+      const record = { cepr: '100000000500000', dob: '01/0f/2000', dtr: 'No dtr' };
+      const result = validator.records(record);
+      expect(result).toHaveProperty('record', record);
+      expect(result).toHaveProperty('valid', false);
+      expect(result).toHaveProperty(
+        'reasons', ['Invalid CEPR value', 'Invalid DOB format', 'Invalid Duty to remove alert value']
+      );
+    });
+  });
+});

--- a/test/unit/ima-config.test.js
+++ b/test/unit/ima-config.test.js
@@ -1,4 +1,4 @@
-const { targetColumns, validator } = require('../../services/ima/config');
+const { targetColumns, validateRecord } = require('../../services/ima/config');
 
 describe('The IMA service config', () => {
   describe('targetColumns array', () => {
@@ -10,7 +10,7 @@ describe('The IMA service config', () => {
   describe('record validator function', () => {
     test('should return the correct result object when passed a properly formatted record.', async () => {
       const record = { cepr: '1000000001', dob: '01/01/2000', dtr: 'Yes' };
-      const result = validator.records(record);
+      const result = validateRecord(record);
       expect(result).toHaveProperty('record', record);
       expect(result).toHaveProperty('valid', true);
       expect(result).not.toHaveProperty('reasons');
@@ -18,7 +18,7 @@ describe('The IMA service config', () => {
 
     test('should return the correct result when passed a record with invalid CEPR value', async () => {
       const record = { cepr: '1001', dob: '01/01/2000', dtr: 'Yes' };
-      const result = validator.records(record);
+      const result = validateRecord(record);
       expect(result).toHaveProperty('record', record);
       expect(result).toHaveProperty('valid', false);
       expect(result).toHaveProperty('reasons', ['Invalid CEPR value']);
@@ -26,7 +26,7 @@ describe('The IMA service config', () => {
 
     test('should return the correct result when passed a record with invalid DOB value', async () => {
       const record = { cepr: '1000000001', dob: '01-01-20', dtr: 'Yes' };
-      const result = validator.records(record);
+      const result = validateRecord(record);
       expect(result).toHaveProperty('record', record);
       expect(result).toHaveProperty('valid', false);
       expect(result).toHaveProperty('reasons', ['Invalid DOB format']);
@@ -34,7 +34,7 @@ describe('The IMA service config', () => {
 
     test('should return the correct result when passed a record with invalid DTR value', async () => {
       const record = { cepr: '1000000001', dob: '01/01/2000', dtr: 'Yeah' };
-      const result = validator.records(record);
+      const result = validateRecord(record);
       expect(result).toHaveProperty('record', record);
       expect(result).toHaveProperty('valid', false);
       expect(result).toHaveProperty('reasons', ['Invalid Duty to remove alert value']);
@@ -42,7 +42,7 @@ describe('The IMA service config', () => {
 
     test('should return the correct result when passed a record with invalid CEPR and DOB value', async () => {
       const record = { cepr: '1000a', dob: '01012000', dtr: 'Yes' };
-      const result = validator.records(record);
+      const result = validateRecord(record);
       expect(result).toHaveProperty('record', record);
       expect(result).toHaveProperty('valid', false);
       expect(result).toHaveProperty('reasons', ['Invalid CEPR value', 'Invalid DOB format']);
@@ -50,7 +50,7 @@ describe('The IMA service config', () => {
 
     test('should return the correct result when passed a record with invalid CEPR and DTR value', async () => {
       const record = { cepr: 'ABCDEFGH', dob: '01/01/2000', dtr: 'Yeah' };
-      const result = validator.records(record);
+      const result = validateRecord(record);
       expect(result).toHaveProperty('record', record);
       expect(result).toHaveProperty('valid', false);
       expect(result).toHaveProperty('reasons', ['Invalid CEPR value', 'Invalid Duty to remove alert value']);
@@ -58,7 +58,7 @@ describe('The IMA service config', () => {
 
     test('should return the correct result when passed a record with invalid DOB and DTR value', async () => {
       const record = { cepr: '1000000001', dob: '1/1/00', dtr: 'Nope' };
-      const result = validator.records(record);
+      const result = validateRecord(record);
       expect(result).toHaveProperty('record', record);
       expect(result).toHaveProperty('valid', false);
       expect(result).toHaveProperty('reasons', ['Invalid DOB format', 'Invalid Duty to remove alert value']);
@@ -66,7 +66,7 @@ describe('The IMA service config', () => {
 
     test('should return the correct result when all record values are invalid', async () => {
       const record = { cepr: '100000000500000', dob: '01/0f/2000', dtr: 'No dtr' };
-      const result = validator.records(record);
+      const result = validateRecord(record);
       expect(result).toHaveProperty('record', record);
       expect(result).toHaveProperty('valid', false);
       expect(result).toHaveProperty(


### PR DESCRIPTION
## What?

* Allow the script to validate rows as they are parsed into JS from CSV. 
* Validation function is set and exported to the main script from service config.
* Made parsed object keys dynamic to values set in service config.
* Updated README with new information.
* Log both valid and invalid records arrays at end of script.
* Improved logging and error handling throughout script and utility functions.

## Why?

[IMB-107](https://collaboration.homeoffice.gov.uk/jira/browse/IMB-107). We need to validate incoming rows as they are parsed from uploaded CSV file into processable JS objects. Validate for IMA that CEPR, DOB and DTR values are in the correct expected format for verification use in the form. Collect invalid records separately from valid. Allow the main script to remain service-agnostic through validation. Valid records will go on to be uploaded to the DB lookup table, Invalid records are kept to be attached to email notifications and not uploaded.

## How?

Introduced service specific config in a similar manner to [hof-rds-api](https://github.com/UKHomeOffice/hof-rds-api). This is selected and imported to the main script based on the `SERVICE_NAME` environment variable.

Just after csv-parse creates an object from key/value pairs (column name/column value) for each row, run a validation function on the object to validate CEPR, DOB, DTR values against pattern matching regex or other conditions. Import the validation function dynamically from above service specific config. Validation is optional according to definition per service.

Used csv-parse config to allow column name to object key name transformation via an optional array also defined per service in config. (This will drastically improve RAM usage for IMA but may not be needed for other services).

## Testing

Tests added for `validateRecord` function in IMA specific config.
Tests updated to allow for file requests where no auth is required.
Tested script manually with valid and invalid CSV of different configuration 

## Anything else?

* Allowed the script to avoid file-vault auth if no token url is provided to the environment. Works for if the script needed to pull from a location with no auth requirement.
* Updated the model.getLatestUrl methods to collect 'created_at' value for the file uploads so that if required the script can determine when it was uploaded and react conditionally.