### PR TITLE
IMB-68: Replace Quay Image Repo Name

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ type: kubernetes
 
 environment:
   IMAGE_URL: quay.io/ukhomeofficedigital
-  IMAGE_REPO: hof-lookup-replacer
+  IMAGE_REPO: hof-db-table-replacer
 
 trigger:
   branch:
@@ -85,7 +85,7 @@ steps:
       DOCKER_PASSWORD:
         from_secret: DOCKER_PASSWORD
     commands:
-    - docker login -u="ukhomeofficedigital+hof_lookup_replacer" -p=$${DOCKER_PASSWORD} quay.io
+    - docker login -u="ukhomeofficedigital+hof_db_table_replacer" -p=$${DOCKER_PASSWORD} quay.io
     - docker tag $${IMAGE_REPO}:$${DRONE_COMMIT_SHA} $${IMAGE_URL}/$${IMAGE_REPO}:$${DRONE_COMMIT_SHA}
     - docker push $${IMAGE_URL}/$${IMAGE_REPO}:$${DRONE_COMMIT_SHA}
     when:
@@ -101,7 +101,7 @@ steps:
         cpu: 1000
         memory: 1024Mi
     environment:
-      IMAGE_NAME: hof-lookup-replacer:${DRONE_COMMIT_SHA}
+      IMAGE_NAME: hof-db-table-replacer:${DRONE_COMMIT_SHA}
       TOLERATE: MEDIUM,HIGH,CRITICAL
       FAIL_ON_DETECTION: false
       IGNORE_UNFIXED: true
@@ -154,11 +154,11 @@ steps:
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
     pull: always
     environment:
-      IMAGE_NAME: hof-lookup-replacer:${DRONE_COMMIT_SHA}
+      IMAGE_NAME: hof-db-table-replacer:${DRONE_COMMIT_SHA}
       SEVERITY: MEDIUM,HIGH,CRITICAL
       FAIL_ON_DETECTION: false
       IGNORE_UNFIXED: true
-      ALLOW_CVE_LIST_FILE: trivy-cve-exceptions.txt
+      ALLOW_CVE_LIST_FILE: hof-services-config/Hof_Db_Table_Replacer/trivy-cve-exceptions.txt
     when:
       cron: security_scans
       event: cron

--- a/.drone.yml
+++ b/.drone.yml
@@ -105,7 +105,7 @@ steps:
       TOLERATE: MEDIUM,HIGH,CRITICAL
       FAIL_ON_DETECTION: false
       IGNORE_UNFIXED: true
-    #  ALLOW_CVE_LIST_FILE: hof-services-config/Electronic_Travel_Authorisation/trivy-cve-exceptions.txt
+      ALLOW_CVE_LIST_FILE: trivy-cve-exceptions.txt
     when:
       event:
       - pull_request
@@ -158,7 +158,7 @@ steps:
       SEVERITY: MEDIUM,HIGH,CRITICAL
       FAIL_ON_DETECTION: false
       IGNORE_UNFIXED: true
-    #  ALLOW_CVE_LIST_FILE: hof-services-config/Electronic_Travel_Authorisation/trivy-cve-exceptions.txt
+      ALLOW_CVE_LIST_FILE: trivy-cve-exceptions.txt
     when:
       cron: security_scans
       event: cron

--- a/.drone.yml
+++ b/.drone.yml
@@ -105,7 +105,7 @@ steps:
       TOLERATE: MEDIUM,HIGH,CRITICAL
       FAIL_ON_DETECTION: false
       IGNORE_UNFIXED: true
-      ALLOW_CVE_LIST_FILE: trivy-cve-exceptions.txt
+      ALLOW_CVE_LIST_FILE: hof-services-config/Hof_Db_Table_Replacer/trivy-cve-exceptions.txt
     when:
       event:
       - pull_request


### PR DESCRIPTION
**What?**
ALLOW_CVE_LIST_FILE set to the path to a file containing a list of allowed CVEs
Place a text file that contains a list of vulnerabilities (CVEs) and comments elsewhere within your repository however you must set environment variable ALLOW_CVE_LIST_FILE to the path of the text file relative to the root of your repository.
Replaced Quay Image repo with "hof-db-table-replacer" to match the git repo and API name

Why?
Path to file containing a list of allowed CVEs. Listing CVEs in a file with ALLOW_CVE_LIST_FILE. Trivy will scan images, file systems and repositories for any vulnerabilities and issues. Trivy is supported by ACP team.
Team has decided to replace the old name of Git repo with "hof-db-table-replacer". and Quay Image repo has been updated accordingly to match with Git repo name

How?
Add missing CVE Exceptions file for trivy.
The Common Vulnerabilities and Exposures (CVE) system establishes a standard for reporting and tracking vulnerabilities. CVE Identifiers are assigned to vulnerabilities to make it easier to share and track information about these issues. 
Drone Pipeline has build and pushed Image to new Image repository


**Testing?**
![image](https://github.com/UKHomeOffice/hof-db-table-replacer/assets/146218064/c1b9edc9-6acd-4faa-a5ff-c412920ebe79)
<img width="1431" alt="image" src="https://github.com/UKHomeOffice/hof-db-table-replacer/assets/146218064/0c6d20bf-ef93-4a42-8e80-923b1056b05c">
<img width="1431" alt="image" src="https://github.com/UKHomeOffice/hof-db-table-replacer/assets/146218064/ab7602fd-c39d-433a-a9cc-a5366604b56c">


